### PR TITLE
Update notes for timer_settime

### DIFF
--- a/notes.txt
+++ b/notes.txt
@@ -1,6 +1,6 @@
-1) timerfd_create vs settimer
+1) timerfd_create vs timer_settime
 
-The difference between settimer()/timer_create() function and timerfd_create() function is how to get the notification of timer expiration. A process in which timerfd_create() is being used will get the notification of timer expiration via a file descriptor while the other process in which settimer()/timer_create() are being used will get SIG_ALRM signal whenever timers are expired, To publish a SIG_ALRM signal inside the kernel, as I know, swapper stops its current job, sends the signal and resumes the job. This kind of action can make performance degradation when many performance-critical processes are being executed.
+The difference between timer_settime()/timer_create() function and timerfd_create() function is how to get the notification of timer expiration. A process in which timerfd_create() is being used will get the notification of timer expiration via a file descriptor while the other process in which timer_settime()/timer_create() are being used will get SIG_ALRM signal whenever timers are expired, To publish a SIG_ALRM signal inside the kernel, as I know, swapper stops its current job, sends the signal and resumes the job. This kind of action can make performance degradation when many performance-critical processes are being executed.
 
 
 2) using alarms to get backtrace for process crash


### PR DESCRIPTION
## Summary
- fix documentation to mention `timer_settime()` instead of the old `settimer()`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68688eb7b3d48325bf6c765b42926fba