### PR TITLE
Fix TimerMgr Tick cleanup and add tests

### DIFF
--- a/scheme1/orderedList.cpp
+++ b/scheme1/orderedList.cpp
@@ -73,6 +73,8 @@ void TimerMgr::Tick() {
             for (auto itm = m.begin(); itm != m.end(); ++itm) {
                 TimerT tMeta = itm->second;
                 tMeta.cb(tMeta.id);
+                // remove fired timer from stop map
+                m_stopMap.erase(tMeta.id);
             }
             //remove this list elem
             m_timerList.pop_front();

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+DIR=$(cd "$(dirname "$0")" && pwd)
+g++ -std=c++11 -Wall -I"$DIR/../scheme1" "$DIR/../scheme1/orderedList.cpp" "$DIR/test_orderedList.cpp" -o "$DIR/test_orderedList"
+"$DIR/test_orderedList"

--- a/tests/test_orderedList.cpp
+++ b/tests/test_orderedList.cpp
@@ -1,0 +1,27 @@
+#include "../scheme1/orderedList.hpp"
+#include <cassert>
+
+int main() {
+    TimerMgr mgr;
+    int fired = 0;
+    int id = mgr.StartTimer(2000, [&](int timerId){ ++fired; });
+
+    mgr.Tick(); // 1 second passed
+    assert(fired == 0);
+    assert(mgr.IsRunning(id));
+
+    mgr.Tick(); // timer should fire
+    assert(fired == 1);
+    assert(!mgr.IsRunning(id));
+
+    fired = 0;
+    int id1 = mgr.StartTimer(1000, [&](int){ ++fired; });
+    int id2 = mgr.StartTimer(1000, [&](int){ ++fired; });
+
+    mgr.Tick();
+    assert(fired == 2);
+    assert(!mgr.IsRunning(id1));
+    assert(!mgr.IsRunning(id2));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- remove expired timer IDs from `m_stopMap` before removing list element
- add simple unit tests verifying timers stop running after firing

## Testing
- `tests/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68689087ba988325840dc79dec266904