### PR TITLE
Add TimerMgr test and Makefile target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Timers
+
+This repository contains a simple timer manager implementation.
+
+## Running the test
+
+A small test program is provided in `scheme1/orderedList_test.cpp`. Build and
+run it using the `test` target of the Makefile:
+
+```bash
+cd scheme1
+make test
+```
+
+The program will build and automatically execute, exiting with status 0 if the
+assertions pass.

--- a/scheme1/Makefile
+++ b/scheme1/Makefile
@@ -1,2 +1,6 @@
 all:
-	g++ -g -Wall -std=c++11 -I. orderedList.cpp main.cpp
+	g++ -g -Wall -std=c++11 -I. orderedList.cpp main.cpp -o timer_app
+
+test:
+	g++ -g -Wall -std=c++11 -I. orderedList.cpp orderedList_test.cpp -o orderedList_test
+	./orderedList_test

--- a/scheme1/orderedList_test.cpp
+++ b/scheme1/orderedList_test.cpp
@@ -1,0 +1,18 @@
+#include "orderedList.hpp"
+#include <cassert>
+
+int main() {
+    TimerMgr mgr;
+    int fired = 0;
+    int id = mgr.StartTimer(2000, [&](int){ ++fired; });
+
+    mgr.Tick(); // 1 second elapsed
+    assert(mgr.IsRunning(id));
+    assert(fired == 0);
+
+    mgr.Tick(); // timer should expire
+    assert(!mgr.IsRunning(id));
+    assert(fired == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a simple test for `TimerMgr`
- extend `Makefile` with a `test` target
- document how to run the test

## Testing
- `./tests/run_tests.sh`
- `cd scheme1 && make test`


------
https://chatgpt.com/codex/tasks/task_e_686896be3bb88325bc827f4d5c892426